### PR TITLE
Add wakelocks during msg proc

### DIFF
--- a/src/protocol/binary_writer.js
+++ b/src/protocol/binary_writer.js
@@ -29,13 +29,11 @@ CoSeMe.namespace('protocol', (function(){
    */
   BinaryWriter.prototype.streamStart = function(domain, resource, callback) {
     var writerTask = this.newWriteTask(callback);
-    setTimeout(function() {
-      writerTask._sendProtocol(IS_COUNTING);
-      writerTask._sendProtocol();
+    writerTask._sendProtocol(IS_COUNTING);
+    writerTask._sendProtocol();
 
-      writerTask._streamStart(domain, resource, IS_COUNTING);
-      writerTask._streamStart(domain, resource);
-    });
+    writerTask._streamStart(domain, resource, IS_COUNTING);
+    writerTask._streamStart(domain, resource);
   };
 
   BinaryWriter.prototype._sendProtocol = function(counting) {
@@ -63,10 +61,8 @@ CoSeMe.namespace('protocol', (function(){
    */
   BinaryWriter.prototype.write = function(tree, callback) {
     var writerTask = this.newWriteTask(callback);
-    setTimeout(function() {
-      writerTask._write(tree, IS_COUNTING);
-      writerTask._write(tree);
-    });
+    writerTask._write(tree, IS_COUNTING);
+    writerTask._write(tree);
   };
 
   /*

--- a/src/yowsup_if.js
+++ b/src/yowsup_if.js
@@ -953,7 +953,7 @@ CoSeMe.namespace('yowsup.connectionmanager', (function() {
     // To-do: To be faithful with Yowsup, this should spawn a thread per handler
     signalHandlers[aSignal].forEach(function (aHandler) {
       try {
-        setTimeout(function() {aHandler.apply(undefined, aParams);}, 0);
+        aHandler.apply(undefined, aParams);
       } catch (x) {
         logger.error('FireEvent exception!', x);
       }


### PR DESCRIPTION
this should prevent the phone going back to sleep before the app is able to acknowledge an incoming message
Application might need to add wakeLocks as well if it needs to prevent phone from going back to sleep during an async callback