### PR TITLE
Sending timestamps of media messages to yowsup signal interface

### DIFF
--- a/src/yowsup_if.js
+++ b/src/yowsup_if.js
@@ -366,7 +366,6 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
         author = messageNode.getAttributeValue("participant"),
         pushName = messageNode.getAttributeValue('notify'),
         msgId = messageNode.getAttributeValue("id"),
-        attribute_t = messageNode.getAttributeValue("t"),
         typeAttribute = messageNode.getAttributeValue("type"),
         wantsReceipt = false;
 
@@ -388,10 +387,12 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
           if (isGroup) {
             _signalInterface.send("group_imageReceived",
                                   [msgId, fromAttribute, author, mediaPreview,
-                                  mediaUrl, mediaSize, wantsReceipt, pushName]);
+                                  mediaUrl, mediaSize, wantsReceipt, pushName,
+                                  timestamp]);
           } else {
             _signalInterface.send("image_received", [msgId, fromAttribute, mediaPreview, mediaUrl,
-                                                     mediaSize, wantsReceipt, isBroadcast, pushName]);
+                                                     mediaSize, wantsReceipt, isBroadcast, pushName,
+                                                     timestamp]);
           }
         },
 
@@ -399,10 +400,11 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
           if (isGroup) {
             _signalInterface.send("group_videoReceived",
                                   [msgId, fromAttribute, author, mediaPreview, mediaUrl,
-                                   mediaSize, wantsReceipt, pushName]);
+                                   mediaSize, wantsReceipt, pushName, timestamp]);
           } else {
             _signalInterface.send("video_received", [msgId, fromAttribute, mediaPreview,
-                                                     mediaUrl, mediaSize, wantsReceipt, isBroadcast, pushName]);
+                                                     mediaUrl, mediaSize, wantsReceipt,
+                                                     isBroadcast, pushName, timestamp]);
           }
         },
 
@@ -411,11 +413,13 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
           if (isGroup) {
             _signalInterface.send("group_audioReceived",
                                   [msgId, fromAttribute, author,
-                                  mediaUrl, mediaSize, wantsReceipt, pushName]);
+                                  mediaUrl, mediaSize, wantsReceipt, pushName,
+                                  timestamp]);
           } else {
             _signalInterface.send("audio_received",
                                   [msgId, fromAttribute, mediaUrl,
-                                  mediaSize, wantsReceipt, isBroadcast, pushName]);
+                                  mediaSize, wantsReceipt, isBroadcast, pushName,
+                                  timestamp]);
           }
         },
 
@@ -428,11 +432,13 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
           if (isGroup) {
             _signalInterface.send("group_locationReceived",
                                   [msgId, fromAttribute, author, name, mediaPreview,
-                                   mlatitude, mlongitude, wantsReceipt, pushName]);
+                                   mlatitude, mlongitude, wantsReceipt, pushName,
+                                   timestamp]);
           } else {
             _signalInterface.send("location_received",
                                   [msgId, fromAttribute, name, mediaPreview, mlatitude,
-                                  mlongitude, wantsReceipt, isBroadcast, pushName]);
+                                  mlongitude, wantsReceipt, isBroadcast, pushName,
+                                  timestamp]);
           }
         },
 
@@ -452,11 +458,13 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
             if (isGroup) {
                 _signalInterface.send("group_vcardReceived",
                                       [msgId, fromAttribute, author, vcardName,
-                                       vcardData, wantsReceipt, pushName]);
+                                       vcardData, wantsReceipt, pushName,
+                                       timestamp]);
             } else {
               _signalInterface.send("vcard_received",
                                     [msgId, fromAttribute, vcardName,
-                                     vcardData, wantsReceipt, isBroadcast, pushName]);
+                                     vcardData, wantsReceipt, isBroadcast, pushName,
+                                     timestamp]);
             }
           }
         }
@@ -563,7 +571,7 @@ CoSeMe.namespace('yowsup.readerThread', (function() {
         if (newSubject) {
           _signalInterface.send("group_subjectReceived",
                                 [msgId, fromAttribute, author, newSubject,
-                                 Number(attribute_t).valueOf(),  receiptRequested]);
+                                 timestamp, receiptRequested]);
         }
       },
 


### PR DESCRIPTION
Currently only the timestamp (sent time) of text messages is passed to the yowsup signal interface.
This PR adds the timestamp to the media messages.

This is needed for mozillahispano/openwapp#72
