### PR TITLE
Update user agent version automatically if it is outdated.

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -1,6 +1,18 @@
 CoSeMe.namespace('config', (function(){
   'use strict';
 
+  var version = localStorage.getItem('userAgentVersion') || '2.13.9';
+
+  function getTokenData() {
+    return {
+      "v": version,
+      // XXX: it is tokenData[d] + - + tokenData[v] + - + port
+      "r": "S40-" + version,
+      "u": "WhatsApp/" + version + " S40Version/14.26 Device/Nokia302",
+      "d": "S40"
+    };
+  }
+
   return {
     logger: true,
 
@@ -10,13 +22,9 @@ CoSeMe.namespace('config', (function(){
 
     groupDomain: 'g.us',
 
-    tokenData: {
-      "v": "2.13.9",
-      // XXX: it is tokenData[d] + - + tokenData[v] + - + port
-      "r": "S40-2.13.9",
-      "u": "WhatsApp/2.13.9 S40Version/14.26 Device/Nokia302",
-      "d": "S40"
-    },
+    versionSource: 'https://coderus.openrepos.net/whitesoft/whatsapp_scratch',
+
+    tokenData: getTokenData(),
 
     auth: {
       host: 'c2.whatsapp.net',
@@ -50,6 +58,27 @@ CoSeMe.namespace('config', (function(){
         "charSet": "utf-8",
         "authMethod": "X-WAWA"
       }
+    },
+
+    updateUserAgentVersion: function(callback) {
+      var _this = this;
+      var xhr = new XMLHttpRequest({mozSystem: true});
+      xhr.open('GET', this.versionSource);
+      xhr.responseType = 'json';
+      xhr.setRequestHeader('Accept', 'text/json');
+      xhr.addEventListener('load', function() {
+        if (this.response.e && this.response.e.match(/^([\d]+(\.[\d]+)*)+$/)) {
+          version = this.response.e;
+          localStorage.setItem('userAgentVersion', version);
+
+          _this.tokenData = getTokenData(); // refresh version in config data
+        }
+        callback && callback();
+      });
+      xhr.addEventListener('error', function() {
+        callback && callback();
+      });
+      xhr.send();
     }
-  }
+  };
 }()));


### PR DESCRIPTION
On regular intervalls WhatsApp updates its client version and requires it on registrations. If the sent version is outdated, a registration is not possible. Until now, the user agent of CoSeMe had to be updated manually by the developers. This is pretty annoying for developers and for users (see https://github.com/mozillahispano/openwapp/issues/204).

So this commit integrates a mechanism which tries to get the latest WhatsApp version from a third party service if it is needed and uses it when the config is built.

@willyaranda The files in `dist` folder should be rebuild after merging this PR. I do not know how it is done. It would be nice if you could give me a short instruction, so that I can do it ;-)
